### PR TITLE
NUD-510 Orgnr quality controls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ssb-nudb-use"
-version = "2026.4.6"  # Year.Month.Patch - So the last number is not day of month, but patch number within month
+version = "2026.4.7"  # Year.Month.Patch - So the last number is not day of month, but patch number within month
 description = "NUDB Use - is a usage-package for the Norwegian National Education Database cloud-data. Both for data-consumers and data-deliverers"
 authors = [{ name = "Carl F. Corneil", email = "cfc@ssb.no" }, { name = "Kjell Slupphaug", email = "pph@ssb.no" }, { name = "Markus Storeide", email = "rku@ssb.no" }]
 maintainers = [{ name = "Statistics Norway, Education statistics Department (360)" }]
@@ -29,7 +29,7 @@ documentation = "https://statisticsnorway.github.io/ssb-nudb-use"
 Changelog = "https://github.com/statisticsnorway/ssb-nudb-use/releases"
 
 [tool.poetry]
-classifiers = ["Development Status :: 3 - Alpha"]
+classifiers = ["Development Status :: 4 - Beta"]
 requires-poetry = ">=2.0"
 packages = [{ include = "nudb_use", from = "src" }]
 

--- a/src/nudb_use/quality/specific_variables/orgnr.py
+++ b/src/nudb_use/quality/specific_variables/orgnr.py
@@ -21,15 +21,15 @@ def check_outdated_orgnr_cols(
         **kwargs: Unused extra arguments for compatibility.
 
     Returns:
-        Collected validation errors.
+        list[NudbQualityError]: Collected validation errors.
     """
+    errors: list[NudbQualityError] = []
     outdated_cols = ["org_nr", "utd_orgnr", "bof_orgnrbed", "orgnr"]
     current_col_names = ["orgnr_foretak", "orgnrbed"]
     outdated_in_df = [c for c in outdated_cols if c in df.columns.str.lower()]
     if outdated_in_df:
-        errors: list[NudbQualityError] = []
         err_msg = f"Found outdated orgnr in your dataset: {outdated_in_df}, we want these: {current_col_names}"
-        add_err2list(errors, err_msg)
+        add_err2list(errors, NudbQualityError(err_msg))
     return errors
 
 
@@ -41,7 +41,7 @@ def check_orgnr_foretak(df: pd.DataFrame, **kwargs: object) -> list[NudbQualityE
         **kwargs: Extra validation options. Set use_external_datasets to run this check.
 
     Returns:
-        Collected validation errors.
+        list[NudbQualityError]: Collected validation errors.
     """
     errors: list[NudbQualityError] = []
     if kwargs.get("use_external_datasets"):
@@ -68,7 +68,7 @@ def check_orgnrbed(df: pd.DataFrame, **kwargs: object) -> list[NudbQualityError]
         **kwargs: Extra validation options. Set use_external_datasets to run this check.
 
     Returns:
-        Collected validation errors.
+        list[NudbQualityError]: Collected validation errors.
     """
     errors: list[NudbQualityError] = []
     if not kwargs.get("use_external_datasets", True):
@@ -112,11 +112,18 @@ def subcheck_col_contains_invalid_orgnr(
         col_name: Name of the column being checked.
 
     Returns:
-        Validation error when invalid orgnr values are found, otherwise None.
+        NudbQualityError | None: Validation error when invalid orgnr values are found, otherwise None.
     """
-    orgnr_foretak, orgnrbed = _split_orgnr_col(col, put_invalid_in_orgnr_foretak=False)
+    validated = require_series_present(orgnr_col=col)
+    if validated is None:
+        return None
+
+    orgnr_col = validated["orgnr_col"]
+    orgnr_foretak, orgnrbed = _split_orgnr_col(
+        orgnr_col, put_invalid_in_orgnr_foretak=False
+    )
     invalid_values: list[str] = list(
-        col[orgnr_foretak.isna() & orgnrbed.isna() & col.notna()].unique()
+        orgnr_col[orgnr_foretak.isna() & orgnrbed.isna() & orgnr_col.notna()].unique()
     )
     if invalid_values:
         return NudbQualityError(
@@ -135,9 +142,14 @@ def subcheck_col_contains_orgnr_foretak(
         col_name: Name of the column being checked.
 
     Returns:
-        Validation error when orgnrbed values are found, otherwise None.
+        NudbQualityError | None: Validation error when orgnrbed values are found, otherwise None.
     """
-    _, orgnrbed = _split_orgnr_col(col)
+    validated = require_series_present(orgnr_col=col)
+    if validated is None:
+        return None
+
+    orgnr_col = validated["orgnr_col"]
+    _, orgnrbed = _split_orgnr_col(orgnr_col)
     orgnrbed_in_foretak = list(orgnrbed[orgnrbed.notna()].unique())
     if orgnrbed_in_foretak:
         return NudbQualityError(
@@ -156,9 +168,14 @@ def subcheck_col_contains_orgnrbed(
         col_name: Name of the column being checked.
 
     Returns:
-        Validation error when orgnr_foretak values are found, otherwise None.
+        NudbQualityError | None: Validation error when orgnr_foretak values are found, otherwise None.
     """
-    orgnr_foretak, _ = _split_orgnr_col(col, put_invalid_in_orgnr_foretak=False)
+    validated = require_series_present(orgnr_col=col)
+    if validated is None:
+        return None
+
+    orgnr_col = validated["orgnr_col"]
+    orgnr_foretak, _ = _split_orgnr_col(orgnr_col, put_invalid_in_orgnr_foretak=False)
     foretak_in_orgnrbed = list(orgnr_foretak[orgnr_foretak.notna()].unique())
     if foretak_in_orgnrbed:
         return NudbQualityError(
@@ -182,7 +199,7 @@ def subcheck_orgnrbed_orgnr_foretak_connected(
         col_orgnrbed_name: Name of the orgnrbed column.
 
     Returns:
-        Validation error when pairs are missing from BOF, otherwise None.
+        NudbQualityError | None: Validation error when pairs are missing from BOF, otherwise None.
     """
     validated = require_series_present(
         orgnr_foretak_col=col_foretak,

--- a/src/nudb_use/quality/specific_variables/orgnr.py
+++ b/src/nudb_use/quality/specific_variables/orgnr.py
@@ -127,7 +127,7 @@ def subcheck_col_contains_invalid_orgnr(
     )
     if invalid_values:
         return NudbQualityError(
-            f"Found invalid values in {col_name} when looking them all up in BoF and Brreg (first 10): {invalid_values[:11] if len(invalid_values) >= 10 else invalid_values}"
+            f"Found {len(invalid_values)} invalid values in {col_name} when looking them all up in BoF and Brreg (first 10): {invalid_values[:11] if len(invalid_values) >= 10 else invalid_values}"
         )
     return None
 

--- a/src/nudb_use/quality/specific_variables/orgnr.py
+++ b/src/nudb_use/quality/specific_variables/orgnr.py
@@ -1,0 +1,245 @@
+import pandas as pd
+
+from nudb_use.datasets.nudb_data import NudbData
+from nudb_use.exceptions.exception_classes import NudbQualityError
+from nudb_use.nudb_logger import LoggerStack
+from nudb_use.nudb_logger import logger
+from nudb_use.variables.specific_vars.orgnr import _split_orgnr_col
+
+from .utils import add_err2list
+from .utils import get_column
+from .utils import require_series_present
+
+
+def check_outdated_orgnr_cols(
+    df: pd.DataFrame, **kwargs: object
+) -> list[NudbQualityError]:
+    """Check for orgnr-columns with old names in the dataset.
+
+    Args:
+        df: Dataset whose column names should be checked.
+        **kwargs: Unused extra arguments for compatibility.
+
+    Returns:
+        Collected validation errors.
+    """
+    outdated_cols = ["org_nr", "utd_orgnr", "bof_orgnrbed", "orgnr"]
+    current_col_names = ["orgnr_foretak", "orgnrbed"]
+    outdated_in_df = [c for c in outdated_cols if c in df.columns.str.lower()]
+    if outdated_in_df:
+        errors: list[NudbQualityError] = []
+        err_msg = f"Found outdated orgnr in your dataset: {outdated_in_df}, we want these: {current_col_names}"
+        add_err2list(errors, err_msg)
+    return errors
+
+
+def check_orgnr_foretak(df: pd.DataFrame, **kwargs: object) -> list[NudbQualityError]:
+    """Validate the orgnr_foretak column against external orgnr sources.
+
+    Args:
+        df: Dataset containing the orgnr_foretak column.
+        **kwargs: Extra validation options. Set use_external_datasets to run this check.
+
+    Returns:
+        Collected validation errors.
+    """
+    errors: list[NudbQualityError] = []
+    if kwargs.get("use_external_datasets"):
+        ...  # Doing it this way to have the guard set up right...
+    else:
+        logger.info(
+            "Skipping checking orgnr_foretak with external dataset, because the use_external_datasets param is set to False."
+        )
+        return errors
+
+    with LoggerStack("Validating orgnr_foretak column."):
+        col_name = "orgnr_foretak"
+        col = get_column(df, col=col_name)
+        add_err2list(errors, subcheck_col_contains_invalid_orgnr(col, col_name))
+        add_err2list(errors, subcheck_col_contains_orgnr_foretak(col, col_name))
+        return errors
+
+
+def check_orgnrbed(df: pd.DataFrame, **kwargs: object) -> list[NudbQualityError]:
+    """Validate the orgnrbed column against external orgnr sources.
+
+    Args:
+        df: Dataset containing the orgnrbed column.
+        **kwargs: Extra validation options. Set use_external_datasets to run this check.
+
+    Returns:
+        Collected validation errors.
+    """
+    errors: list[NudbQualityError] = []
+    if not kwargs.get("use_external_datasets", True):
+        logger.info(
+            "Skipping checking orgnrbed with external dataset, because the use_external_datasets param is set to False."
+        )
+        return errors
+    with LoggerStack("Validating orgnrbed column."):
+        col_name = "orgnrbed"
+        col = get_column(df, col=col_name)
+        add_err2list(errors, subcheck_col_contains_invalid_orgnr(col, col_name))
+        add_err2list(errors, subcheck_col_contains_orgnrbed(col, col_name))
+
+        want_col = "orgnr_foretak"
+        want_series = get_column(df, col=want_col)
+        validated = require_series_present(orgnr_foretak_col=want_series)
+        if validated is not None:
+            add_err2list(
+                errors,
+                subcheck_orgnrbed_orgnr_foretak_connected(
+                    col_foretak=want_series,
+                    col_foretak_name=want_col,
+                    col_orgnrbed=col,
+                    col_orgnrbed_name=col_name,
+                ),
+            )
+        else:
+            logger.info(
+                f"Didnt find accompanying {want_col} column when I found {col_name}, hard to look at the connections then."
+            )
+        return errors
+
+
+def subcheck_col_contains_invalid_orgnr(
+    col: pd.Series | None, col_name: str
+) -> NudbQualityError | None:
+    """Check whether a column contains values that are neither foretak nor orgnrbed.
+
+    Args:
+        col: Column with orgnr values to validate.
+        col_name: Name of the column being checked.
+
+    Returns:
+        Validation error when invalid orgnr values are found, otherwise None.
+    """
+    orgnr_foretak, orgnrbed = _split_orgnr_col(col, put_invalid_in_orgnr_foretak=False)
+    invalid_values: list[str] = list(
+        col[orgnr_foretak.isna() & orgnrbed.isna() & col.notna()].unique()
+    )
+    if invalid_values:
+        return NudbQualityError(
+            f"Found invalid values in {col_name} when looking them all up in BoF and Brreg (first 10): {invalid_values[:11] if len(invalid_values) >= 10 else invalid_values}"
+        )
+    return None
+
+
+def subcheck_col_contains_orgnr_foretak(
+    col: pd.Series | None, col_name: str
+) -> NudbQualityError | None:
+    """Check whether an orgnr_foretak column contains orgnrbed values.
+
+    Args:
+        col: Column expected to contain only orgnr_foretak values.
+        col_name: Name of the column being checked.
+
+    Returns:
+        Validation error when orgnrbed values are found, otherwise None.
+    """
+    _, orgnrbed = _split_orgnr_col(col)
+    orgnrbed_in_foretak = list(orgnrbed[orgnrbed.notna()].unique())
+    if orgnrbed_in_foretak:
+        return NudbQualityError(
+            f"Found {len(orgnrbed_in_foretak)} orgnrbed-values in {col_name}-column (first 10): {orgnrbed_in_foretak[:11] if len(orgnrbed_in_foretak) >= 10 else orgnrbed_in_foretak}"
+        )
+    return None
+
+
+def subcheck_col_contains_orgnrbed(
+    col: pd.Series | None, col_name: str
+) -> NudbQualityError | None:
+    """Check whether an orgnrbed column contains orgnr_foretak values.
+
+    Args:
+        col: Column expected to contain only orgnrbed values.
+        col_name: Name of the column being checked.
+
+    Returns:
+        Validation error when orgnr_foretak values are found, otherwise None.
+    """
+    orgnr_foretak, _ = _split_orgnr_col(col, put_invalid_in_orgnr_foretak=False)
+    foretak_in_orgnrbed = list(orgnr_foretak[orgnr_foretak.notna()].unique())
+    if foretak_in_orgnrbed:
+        return NudbQualityError(
+            f"Found {len(foretak_in_orgnrbed)} orgnr_foretak-values in {col_name}-column (first 10): {foretak_in_orgnrbed[:11] if len(foretak_in_orgnrbed) >= 10 else foretak_in_orgnrbed}"
+        )
+    return None
+
+
+def subcheck_orgnrbed_orgnr_foretak_connected(
+    col_foretak: pd.Series | None,
+    col_foretak_name: str,
+    col_orgnrbed: pd.Series | None,
+    col_orgnrbed_name: str,
+) -> NudbQualityError | None:
+    """Check whether orgnr_foretak and orgnrbed pairs exist in BOF.
+
+    Args:
+        col_foretak: Column containing orgnr_foretak values.
+        col_foretak_name: Name of the orgnr_foretak column.
+        col_orgnrbed: Column containing orgnrbed values.
+        col_orgnrbed_name: Name of the orgnrbed column.
+
+    Returns:
+        Validation error when pairs are missing from BOF, otherwise None.
+    """
+    validated = require_series_present(
+        orgnr_foretak_col=col_foretak,
+        orgnrbed_col=col_orgnrbed,
+    )
+    if validated is None:
+        return None
+
+    check_connections = pd.concat([col_foretak, col_orgnrbed], axis=1)
+    check_connections.columns = [col_foretak_name, col_orgnrbed_name]
+    check_connections = check_connections[check_connections.notna().all(axis=1)]
+    check_connections = check_connections.astype("string").drop_duplicates()
+
+    if check_connections.empty:
+        return None
+
+    orgnr_foretak_str = "', '".join(
+        str(value).replace("'", "''")
+        for value in check_connections[col_foretak_name].unique()
+    )
+    orgnrbed_str = "', '".join(
+        str(value).replace("'", "''")
+        for value in check_connections[col_orgnrbed_name].unique()
+    )
+    bof_connections = (
+        NudbData("_bof_dated_orgnr_connections")
+        .select("DISTINCT orgnr, orgnrbed")
+        .where(
+            f"""orgnr in ('{orgnr_foretak_str}') OR orgnrbed in ('{orgnrbed_str}')"""
+        )
+        .df()
+        .astype("string")
+        .rename(columns={"orgnr": col_foretak_name})
+    )
+
+    missing_connections_df = check_connections.merge(
+        bof_connections,
+        on=[col_foretak_name, col_orgnrbed_name],
+        how="left",
+        indicator=True,
+    )
+    missing_connections_df = missing_connections_df[
+        missing_connections_df["_merge"] == "left_only"
+    ][[col_foretak_name, col_orgnrbed_name]]
+
+    if missing_connections_df.empty:
+        return None
+
+    missing_connections = {
+        str(orgnr_foretak): sorted(
+            group[col_orgnrbed_name].dropna().astype(str).unique().tolist()
+        )
+        for orgnr_foretak, group in missing_connections_df.groupby(
+            col_foretak_name, sort=False
+        )
+    }
+    first_ten_missing_connections = dict(list(missing_connections.items())[:10])
+    return NudbQualityError(
+        f"Found {len(missing_connections_df)} {col_foretak_name}/{col_orgnrbed_name}-connections that don't exist in BoF (first 10): {first_ten_missing_connections}"
+    )

--- a/src/nudb_use/quality/specific_variables/run_all.py
+++ b/src/nudb_use/quality/specific_variables/run_all.py
@@ -12,6 +12,9 @@ from .grunnskolepoeng import check_grunnskolepoeng
 from .kommune import check_kommune
 from .land import check_land
 from .nus2000 import check_nus2000
+from .orgnr import check_orgnr_foretak
+from .orgnr import check_orgnrbed
+from .orgnr import check_outdated_orgnr_cols
 from .sn07 import check_sn07
 from .snr_fnr import check_has_personal_ids
 from .unique_per_person import check_unique_per_person
@@ -27,6 +30,9 @@ VARIABLE_CHECKS = [
     check_sn07,
     check_unique_per_person,
     check_has_personal_ids,
+    check_outdated_orgnr_cols,
+    check_orgnr_foretak,
+    check_orgnrbed,
 ]
 
 # variable check functions should all take a dataframe as an argument

--- a/src/nudb_use/quality/suite.py
+++ b/src/nudb_use/quality/suite.py
@@ -11,10 +11,8 @@ from nudb_use.quality.check_bool_string_columns import check_bool_string_columns
 from nudb_use.quality.duplicated_columns import check_duplicated_columns
 from nudb_use.quality.missing import check_columns_only_missing
 from nudb_use.quality.missing import check_missing_thresholds_dataset_name
+from nudb_use.quality.outdated_variables import check_outdated_variables
 from nudb_use.quality.specific_variables import run_all_specific_variable_tests
-from nudb_use.quality.specific_variables.outdated_variables import (
-    check_outdated_variables,
-)
 from nudb_use.quality.widths import check_column_widths
 from nudb_use.variables.checks import check_column_presence
 

--- a/src/nudb_use/quality/suite.py
+++ b/src/nudb_use/quality/suite.py
@@ -11,8 +11,10 @@ from nudb_use.quality.check_bool_string_columns import check_bool_string_columns
 from nudb_use.quality.duplicated_columns import check_duplicated_columns
 from nudb_use.quality.missing import check_columns_only_missing
 from nudb_use.quality.missing import check_missing_thresholds_dataset_name
-from nudb_use.quality.outdated_variables import check_outdated_variables
 from nudb_use.quality.specific_variables import run_all_specific_variable_tests
+from nudb_use.quality.specific_variables.outdated_variables import (
+    check_outdated_variables,
+)
 from nudb_use.quality.widths import check_column_widths
 from nudb_use.variables.checks import check_column_presence
 
@@ -23,6 +25,7 @@ def run_quality_suite(
     data_time_start: str | None = None,
     data_time_end: str | None = None,
     raise_errors: bool = True,
+    use_external_datasets: bool = True,
     **kwargs: object,
 ) -> Sequence[Exception]:
     """Run the full NUDB quality suite over a dataset.
@@ -33,6 +36,7 @@ def run_quality_suite(
         data_time_start: Optional start date used by codelist validations.
         data_time_end: Optional end date used by codelist validations.
         raise_errors: When True, raise grouped exceptions if any check fails.
+        use_external_datasets: When True will use external datasets (not Nudbs datasets) to verify data.
         **kwargs: Additional keyword arguments forwarded to specific checks.
 
     Returns:
@@ -54,7 +58,11 @@ def run_quality_suite(
     errors += check_column_widths(df, raise_errors=False)
     errors += check_bool_string_columns(df, raise_errors=False)
     errors += run_all_specific_variable_tests(
-        df, dataset_name=dataset_name, raise_errors=False, **kwargs
+        df,
+        dataset_name=dataset_name,
+        raise_errors=False,
+        use_external_datasets=use_external_datasets,
+        **kwargs,
     )
     errors += check_klass_codes(df, data_time_start, data_time_end, raise_errors=False)
     errors += check_columns_only_missing(df, raise_errors=False)

--- a/src/nudb_use/quality/suite.py
+++ b/src/nudb_use/quality/suite.py
@@ -55,6 +55,13 @@ def run_quality_suite(
     errors += check_duplicated_columns(df)
     errors += check_column_widths(df, raise_errors=False)
     errors += check_bool_string_columns(df, raise_errors=False)
+
+    errors += check_klass_codes(df, data_time_start, data_time_end, raise_errors=False)
+    errors += check_columns_only_missing(df, raise_errors=False)
+    errors += check_missing_thresholds_dataset_name(
+        df, dataset_name=dataset_name, raise_errors=False
+    )
+
     errors += run_all_specific_variable_tests(
         df,
         dataset_name=dataset_name,
@@ -62,12 +69,6 @@ def run_quality_suite(
         use_external_datasets=use_external_datasets,
         **kwargs,
     )
-    errors += check_klass_codes(df, data_time_start, data_time_end, raise_errors=False)
-    errors += check_columns_only_missing(df, raise_errors=False)
-    errors += check_missing_thresholds_dataset_name(
-        df, dataset_name=dataset_name, raise_errors=False
-    )
-
     if errors and raise_errors:
         raise_exception_group(errors)
     if not errors:

--- a/src/nudb_use/variables/specific_vars/orgnr.py
+++ b/src/nudb_use/variables/specific_vars/orgnr.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from nudb_use.datasets.nudb_data import NudbData
 from nudb_use.datasets.nudb_database import nudb_database
+from nudb_use.metadata.external_apis.brreg_api import get_enhet
 from nudb_use.metadata.external_apis.brreg_api import orgnr_is_underenhet
 from nudb_use.nudb_logger import LoggerStack
 from nudb_use.nudb_logger import logger
@@ -155,7 +156,9 @@ def _empty_orgnr_sentinel_values(s: pd.Series) -> pd.Series:
     return s
 
 
-def _split_orgnr_col(orgnr_col: pd.Series) -> tuple[pd.Series, pd.Series]:
+def _split_orgnr_col(
+    orgnr_col: pd.Series, put_invalid_in_orgnr_foretak: bool = True
+) -> tuple[pd.Series, pd.Series]:
     bof_orgnrbed = NudbData("_bof_unique_orgnrbed").df()["orgnrbed"]
     bof_orgnr_foretak = NudbData("_bof_unique_orgnr_foretak").df()["orgnr"]
     is_bed = orgnr_col.isin(bof_orgnrbed)
@@ -177,7 +180,17 @@ def _split_orgnr_col(orgnr_col: pd.Series) -> tuple[pd.Series, pd.Series]:
     orgnrbed_out = pd.Series(pd.NA, index=orgnr_col.index, dtype="string[pyarrow]")
     orgnrbed_out[mask_orgnrbed] = orgnr_col
     orgnr_foretak_out = pd.Series(pd.NA, index=orgnr_col.index, dtype="string[pyarrow]")
-    orgnr_foretak_out.loc[~mask_orgnrbed] = orgnr_col
+    if put_invalid_in_orgnr_foretak:
+        orgnr_foretak_out.loc[~mask_orgnrbed] = orgnr_col
+    else:
+        # Do the work with actually looking these up in brreg, maybe for the second time
+        is_orgnr_foretak_missing: list[str] = []
+        for nr in _progress(missing_from_bof):
+            if get_enhet(nr) is not None:
+                is_orgnr_foretak_missing.append(nr)
+        orgnr_foretak_out.loc[is_foretak | orgnr_col.isin(is_orgnr_foretak_missing)] = (
+            orgnr_col
+        )
     return _empty_orgnr_sentinel_values(
         orgnr_foretak_out
     ), _empty_orgnr_sentinel_values(orgnrbed_out)

--- a/tests/quality/specific_variables/test_orgnr.py
+++ b/tests/quality/specific_variables/test_orgnr.py
@@ -1,0 +1,214 @@
+from typing import Any
+
+import pandas as pd
+
+import nudb_use.quality.specific_variables.orgnr as orgnr_quality
+from nudb_use.exceptions.exception_classes import NudbQualityError
+from nudb_use.quality.specific_variables.orgnr import check_orgnr_foretak
+from nudb_use.quality.specific_variables.orgnr import check_orgnrbed
+from nudb_use.quality.specific_variables.orgnr import check_outdated_orgnr_cols
+from nudb_use.quality.specific_variables.orgnr import (
+    subcheck_col_contains_invalid_orgnr,
+)
+from nudb_use.quality.specific_variables.orgnr import (
+    subcheck_orgnrbed_orgnr_foretak_connected,
+)
+
+FORETAK_VALUES = {
+    "100000001",
+    "100000002",
+    "100000003",
+    "100000099",
+}
+ORGNRBED_VALUES = {
+    "200000001",
+    "200000002",
+    "200000003",
+    "200000099",
+}
+
+
+def _stub_split_orgnr_col(
+    col: pd.Series,
+    put_invalid_in_orgnr_foretak: bool = True,
+) -> tuple[pd.Series, pd.Series]:
+    orgnr_foretak = pd.Series(pd.NA, index=col.index, dtype="string")
+    orgnrbed = pd.Series(pd.NA, index=col.index, dtype="string")
+
+    orgnr_foretak.loc[col.isin(FORETAK_VALUES)] = col
+    orgnrbed.loc[col.isin(ORGNRBED_VALUES)] = col
+
+    if put_invalid_in_orgnr_foretak:
+        orgnr_foretak.loc[col.notna() & orgnr_foretak.isna() & orgnrbed.isna()] = col
+
+    return orgnr_foretak, orgnrbed
+
+
+def test_check_outdated_orgnr_cols_reports_old_names() -> None:
+    df = pd.DataFrame({"org_nr": ["100000001"], "keep": [1]})
+
+    errors = check_outdated_orgnr_cols(df)
+
+    assert len(errors) == 1
+    assert isinstance(errors[0], NudbQualityError)
+    assert "org_nr" in str(errors[0])
+    assert "orgnr_foretak" in str(errors[0])
+
+
+def test_subcheck_col_contains_invalid_orgnr_reports_unknown_values(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(orgnr_quality, "_split_orgnr_col", _stub_split_orgnr_col)
+
+    err = subcheck_col_contains_invalid_orgnr(
+        pd.Series(["100000001", "999999999", pd.NA], dtype="string"),
+        "orgnr_foretak",
+    )
+
+    assert isinstance(err, NudbQualityError)
+    assert "999999999" in str(err)
+
+
+def test_check_orgnr_foretak_reports_orgnrbed_values(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(orgnr_quality, "_split_orgnr_col", _stub_split_orgnr_col)
+    df = pd.DataFrame(
+        {
+            "orgnr_foretak": pd.Series(
+                ["100000001", "200000099"],
+                dtype="string",
+            )
+        }
+    )
+
+    errors = check_orgnr_foretak(df, use_external_datasets=True)
+
+    assert len(errors) == 1
+    assert isinstance(errors[0], NudbQualityError)
+    assert "orgnrbed-values" in str(errors[0])
+    assert "200000099" in str(errors[0])
+
+
+def test_check_orgnrbed_reports_orgnr_foretak_values(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(orgnr_quality, "_split_orgnr_col", _stub_split_orgnr_col)
+    df = pd.DataFrame(
+        {
+            "orgnrbed": pd.Series(
+                ["200000001", "100000099"],
+                dtype="string",
+            )
+        }
+    )
+
+    errors = check_orgnrbed(df, use_external_datasets=True)
+
+    assert len(errors) == 1
+    assert isinstance(errors[0], NudbQualityError)
+    assert "orgnr_foretak-values" in str(errors[0])
+    assert "100000099" in str(errors[0])
+
+
+def test_subcheck_orgnrbed_orgnr_foretak_connected_reports_missing_bof_pairs(
+    monkeypatch: Any,
+) -> None:
+    bof_connections = pd.DataFrame(
+        {
+            "orgnr": ["100000001", "100000002"],
+            "orgnrbed": ["200000001", "200000002"],
+        },
+        dtype="string",
+    )
+
+    class FakeNudbData:
+        def __init__(self, name: str) -> None:
+            assert name == "_bof_dated_orgnr_connections"
+
+        def select(self, expr: str) -> "FakeNudbData":
+            assert expr == "DISTINCT orgnr, orgnrbed"
+            return self
+
+        def where(self, expr: str) -> "FakeNudbData":
+            assert "orgnr in" in expr
+            assert "orgnrbed in" in expr
+            return self
+
+        def df(self) -> pd.DataFrame:
+            return bof_connections.copy()
+
+    monkeypatch.setattr(orgnr_quality, "NudbData", FakeNudbData)
+
+    err = subcheck_orgnrbed_orgnr_foretak_connected(
+        col_foretak=pd.Series(
+            ["100000001", "100000002", "100000003"],
+            dtype="string",
+        ),
+        col_foretak_name="orgnr_foretak",
+        col_orgnrbed=pd.Series(
+            ["200000001", "200000002", "200000003"],
+            dtype="string",
+        ),
+        col_orgnrbed_name="orgnrbed",
+    )
+
+    assert isinstance(err, NudbQualityError)
+    err_msg = str(err)
+    assert "Found 1 orgnr_foretak/orgnrbed-connections" in err_msg
+    assert "100000003" in err_msg
+    assert "200000003" in err_msg
+    assert "100000001" not in err_msg
+    assert "200000001" not in err_msg
+
+
+def test_check_orgnrbed_reports_invalid_connections_with_stubbed_bof(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(orgnr_quality, "_split_orgnr_col", _stub_split_orgnr_col)
+
+    bof_connections = pd.DataFrame(
+        {
+            "orgnr": ["100000001", "100000002"],
+            "orgnrbed": ["200000001", "200000002"],
+        },
+        dtype="string",
+    )
+
+    class FakeNudbData:
+        def __init__(self, name: str) -> None:
+            assert name == "_bof_dated_orgnr_connections"
+
+        def select(self, expr: str) -> "FakeNudbData":
+            return self
+
+        def where(self, expr: str) -> "FakeNudbData":
+            return self
+
+        def df(self) -> pd.DataFrame:
+            return bof_connections.copy()
+
+    monkeypatch.setattr(orgnr_quality, "NudbData", FakeNudbData)
+
+    df = pd.DataFrame(
+        {
+            "orgnr_foretak": pd.Series(
+                ["100000001", "100000002", "100000003"],
+                dtype="string",
+            ),
+            "orgnrbed": pd.Series(
+                ["200000001", "200000003", "200000002"],
+                dtype="string",
+            ),
+        }
+    )
+
+    errors = check_orgnrbed(df, use_external_datasets=True)
+
+    assert len(errors) == 1
+    err_msg = str(errors[0])
+    assert "Found 2 orgnr_foretak/orgnrbed-connections" in err_msg
+    assert "100000002" in err_msg
+    assert "200000003" in err_msg
+    assert "100000003" in err_msg
+    assert "200000002" in err_msg


### PR DESCRIPTION
Nye kvalitetskontroller inn i run_quality_suite.
- Har du en orgnr-kolonne (gamle navn)? FyFy
- Har du verdier i orgnr-kolonnene som aldri har vært orgnr_foretak eller orgnrbed?
- Er det som ligger i orgnr_foretak foretaksorgnr?
- Er det som ligger i orgnrbed bedriftsorgnr?
- Er koblingen mellom utfylt orgnr_foretak og orgnrbed en knytning som har eksistert historisk i vof?

De som er avhengig av eksterne dataset kan skrus av med det nye parameteret `use_external_datasets=False`
(alle unntatt de som går på kolonnenavn blir da skrudd av)