### PR TITLE
Add prototype for delivering variables to Microdata.no

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ssb-nudb-use"
-version = "2026.4.7"  # Year.Month.Patch - So the last number is not day of month, but patch number within month
+version = "2026.4.8"  # Year.Month.Patch - So the last number is not day of month, but patch number within month
 description = "NUDB Use - is a usage-package for the Norwegian National Education Database cloud-data. Both for data-consumers and data-deliverers"
 authors = [{ name = "Carl F. Corneil", email = "cfc@ssb.no" }, { name = "Kjell Slupphaug", email = "pph@ssb.no" }, { name = "Markus Storeide", email = "rku@ssb.no" }]
 maintainers = [{ name = "Statistics Norway, Education statistics Department (360)" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ssb-nudb-use"
-version = "2026.5.0"  # Year.Month.Patch - So the last number is not day of month, but patch number within month
+version = "2026.5.1"  # Year.Month.Patch - So the last number is not day of month, but patch number within month
 description = "NUDB Use - is a usage-package for the Norwegian National Education Database cloud-data. Both for data-consumers and data-deliverers"
 authors = [{ name = "Carl F. Corneil", email = "cfc@ssb.no" }, { name = "Kjell Slupphaug", email = "pph@ssb.no" }, { name = "Markus Storeide", email = "rku@ssb.no" }]
 maintainers = [{ name = "Statistics Norway, Education statistics Department (360)" }]

--- a/src/nudb_use/__init__.py
+++ b/src/nudb_use/__init__.py
@@ -4,6 +4,8 @@ import importlib.metadata
 
 from nudb_config import settings
 
+from nudb_use.datasets.microdata import MicroData
+from nudb_use.datasets.nudb_data import NudbData
 from nudb_use.metadata import find_var
 from nudb_use.metadata import find_vars
 from nudb_use.metadata import get_dtypes
@@ -21,6 +23,8 @@ from nudb_use.variables import derive
 
 __all__ = [
     "LoggerStack",
+    "MicorData",
+    "NudbData",
     "derive",
     "find_var",
     "find_vars",

--- a/src/nudb_use/__init__.py
+++ b/src/nudb_use/__init__.py
@@ -23,7 +23,7 @@ from nudb_use.variables import derive
 
 __all__ = [
     "LoggerStack",
-    "MicorData",
+    "MicroData",
     "NudbData",
     "derive",
     "find_var",

--- a/src/nudb_use/datasets/__init__.py
+++ b/src/nudb_use/datasets/__init__.py
@@ -1,7 +1,8 @@
 """Dataset-derivation helpers for NUDB pipelines."""
 
+from .microdata import MicroData
 from .nudb_data import NudbData
 from .nudb_database import reset_nudb_database
 from .nudb_database import show_nudb_datasets
 
-__all__ = ["NudbData", "reset_nudb_database", "show_nudb_datasets"]
+__all__ = ["MicroData", "NudbData", "reset_nudb_database", "show_nudb_datasets"]

--- a/src/nudb_use/datasets/external.py
+++ b/src/nudb_use/datasets/external.py
@@ -3,9 +3,9 @@ from functools import partial
 import duckdb as db
 from nudb_config import settings
 
-from nudb_use import LoggerStack
 from nudb_use.datasets.utils import _default_alias_from_name
 from nudb_use.datasets.utils import _nudb_data_select_all
+from nudb_use.nudb_logger import LoggerStack
 from nudb_use.paths.latest import latest_shared_path
 
 __all__ = []

--- a/src/nudb_use/datasets/microdata.py
+++ b/src/nudb_use/datasets/microdata.py
@@ -1,0 +1,45 @@
+from typing import Any
+
+from nudb_use.datasets.nudb_data import NudbData
+from nudb_use.datasets.nudb_database import MICRODATA_PREFIX
+from nudb_use.datasets.nudb_database import show_nudb_datasets
+
+
+def show_available_microdata_variables() -> list[str]:
+    """Get available Microdata variables.
+
+    Returns:
+        list[str]: A list with variable names.
+    """
+    datasets = show_nudb_datasets(show_private=True)
+
+    return [
+        dataset.removeprefix(MICRODATA_PREFIX)
+        for dataset in datasets
+        if dataset.startswith(MICRODATA_PREFIX)
+    ]
+
+
+def MicroData(name: str, *args: Any, **kwargs: Any) -> NudbData:
+    """Get Microdata variable as NudbData.
+
+    Args:
+        name: Name of the dataset.
+        *args: Unnamed arguments passed on to NudbData
+        **kwargs: Named arguments passed on to the NudbData.
+
+    Returns:
+        NudbData: Variable in NudbData format
+
+    Raises:
+        ValueError: If the dataset name isn't recognized.
+    """
+    available = show_available_microdata_variables()
+
+    if name not in available:
+        raise ValueError(
+            f"Unrecognized Microdata Variable!\nAvailable variables:\n\t{available}"
+        )
+
+    microdata_name = MICRODATA_PREFIX + name
+    return NudbData(microdata_name, *args, **kwargs)

--- a/src/nudb_use/datasets/microdata.py
+++ b/src/nudb_use/datasets/microdata.py
@@ -20,26 +20,26 @@ def show_available_microdata_variables() -> list[str]:
     ]
 
 
-def MicroData(name: str, *args: Any, **kwargs: Any) -> NudbData:
-    """Get Microdata variable as NudbData.
+class MicroData(NudbData):
+    """Lazy representation of a Microdata variable as an NUDB dataset.
 
     Args:
-        name: Name of the dataset.
-        *args: Unnamed arguments passed on to NudbData
-        **kwargs: Named arguments passed on to the NudbData.
-
-    Returns:
-        NudbData: Variable in NudbData format
+        name: Name of the microdata variable.
+        *args: Unnamed arguments passed on to the dataset generator.
+        **kwargs: Named arguments passed on to the dataset generator.
 
     Raises:
-        ValueError: If the dataset name isn't recognized.
+        ValueError: If the variable name isn't recognized.
     """
-    available = show_available_microdata_variables()
 
-    if name not in available:
-        raise ValueError(
-            f"Unrecognized Microdata Variable!\nAvailable variables:\n\t{available}"
-        )
+    def __init__(self, name: str, *args: Any, **kwargs: Any) -> None:
 
-    microdata_name = MICRODATA_PREFIX + name
-    return NudbData(microdata_name, *args, **kwargs)
+        available = show_available_microdata_variables()
+
+        if name not in available:
+            raise ValueError(
+                f"Unrecognized Microdata Variable!\nAvailable variables:\n\t{available}"
+            )
+
+        microdata_name = MICRODATA_PREFIX + name
+        super().__init__(microdata_name, *args, **kwargs)

--- a/src/nudb_use/datasets/microdata_variables/__init__.py
+++ b/src/nudb_use/datasets/microdata_variables/__init__.py
@@ -3,3 +3,5 @@
 from nudb_use.datasets.microdata_variables.utd_hoeyeste_nus2000 import (
     _generate_microdata_utd_hoeyeste_nus2000_view,
 )
+
+__all__ = ["_generate_microdata_utd_hoeyeste_nus2000_view"]

--- a/src/nudb_use/datasets/microdata_variables/__init__.py
+++ b/src/nudb_use/datasets/microdata_variables/__init__.py
@@ -1,0 +1,5 @@
+"""Module with NudbData generators for Microdata variables."""
+
+from nudb_use.datasets.microdata_variables.utd_hoeyeste_nus2000 import (
+    _generate_microdata_utd_hoeyeste_nus2000_view,
+)

--- a/src/nudb_use/datasets/microdata_variables/utd_hoeyeste_nus2000.py
+++ b/src/nudb_use/datasets/microdata_variables/utd_hoeyeste_nus2000.py
@@ -1,0 +1,41 @@
+import duckdb as db
+
+from nudb_use.nudb_logger import logger
+
+
+def _generate_microdata_utd_hoeyeste_nus2000_view(
+    alias: str,
+    connection: db.DuckDBPyConnection,
+) -> None:
+    from nudb_use.datasets import NudbData  # Avoids circular import
+
+    utd_hoeyeste_view = NudbData("utd_hoeyeste")
+    logger.info("Deriving `utd_hoeyeste_nus2000` Microdata variable.")
+
+    query = f"""
+        CREATE OR REPLACE VIEW _TEMP_CATALOGUE AS (
+            SELECT
+                snr, utd_hoeyeste_nus2000, utd_hoeyeste_dato,
+                ROW_NUMBER() OVER (PARTITION BY snr ORDER BY utd_hoeyeste_dato ASC) AS index
+            FROM
+                {utd_hoeyeste_view.alias}
+        );
+
+        CREATE OR REPLACE VIEW {alias} AS (
+            SELECT
+                T1.snr AS snr,
+                T1.utd_hoeyeste_nus2000 AS utd_hoeyeste_nus2000,
+                T1.utd_hoeyeste_dato AS gyldig_fra_dato,
+                T2.utd_hoeyeste_dato AS gyltid_til_dato
+            FROM
+                _TEMP_CATALOGUE AS T1
+            LEFT JOIN
+                _TEMP_CATALOGUE AS T2
+            ON
+                T1.snr = T2.snr AND
+                T1.index + 1 = T2.index
+        );
+
+    """
+
+    connection.execute(query)

--- a/src/nudb_use/datasets/nudb_data.py
+++ b/src/nudb_use/datasets/nudb_data.py
@@ -151,8 +151,11 @@ class NudbData:
         query = self._get_query()
         return nudb_database.get_connection().sql(query).df()
 
-    def sql(self, expr: str) -> Any:
+    def sql(self, expr: str | None = None) -> Any:
         """Use sql method of database connection."""
+        if expr is None:
+            expr = self._get_query()
+
         return nudb_database.get_connection().sql(expr)
 
     def execute(self, expr: str) -> Any:

--- a/src/nudb_use/datasets/nudb_database.py
+++ b/src/nudb_use/datasets/nudb_database.py
@@ -21,6 +21,9 @@ from nudb_use.datasets.eksamen import _generate_eksamen_hoeyeste_view
 from nudb_use.datasets.eksamen import _generate_eksamen_view
 from nudb_use.datasets.igang import _generate_igang_view
 from nudb_use.datasets.macros import _DUCKDB_MACROS
+from nudb_use.datasets.microdata_variables import (
+    _generate_microdata_utd_hoeyeste_nus2000_view,
+)
 from nudb_use.datasets.nuskat import _generate_nuskat_table
 from nudb_use.datasets.person import _generate_bokommune_16aar_snr
 from nudb_use.datasets.person import _generate_slekt_snr_view
@@ -39,6 +42,7 @@ from nudb_use.nudb_logger import logger
 if TYPE_CHECKING:
     from nudb_use.datasets.nudb_data import NudbData
 
+MICRODATA_PREFIX = "_microdata_"
 STRING_DTYPE = DTYPE_MAPPINGS["pandas"][STRING_DTYPE_NAME]
 GeneratorFunc = Callable[..., None] | Callable[[str, db.DuckDBPyConnection], None]
 
@@ -57,6 +61,7 @@ class _NudbDatabase:
         self._duckdb_temp_dir_path: Path | None = None
 
         self._dataset_generators: dict[str, GeneratorFunc] = {
+            # NudbData() - Public
             "eksamen_aggregated": _generate_eksamen_aggregated_view,
             "eksamen": _generate_eksamen_view,
             "avslutta": _generate_avslutta_view,
@@ -67,16 +72,20 @@ class _NudbDatabase:
             "eksamen_avslutta_hoeyeste": _generate_eksamen_avslutta_hoeyeste_view,
             "utd_hoeyeste": _generate_utd_hoeyeste_view,
             "utd_hoeyeste_last": _generate_utd_hoeyeste_last_view,
-            "_snrkat_fnr2snr": _generate_snrkat_fnr2snr_view,
             "slekt_snr": _generate_slekt_snr_view,
-            "_snr2alder16": _generate_snr2alder16_view,
             "utd_foreldres_utdnivaa": _generate_utd_foreldres_utdnivaa_view,
             "utd_person": _generate_utd_person_view,
             "bokommune_16aar_snr": _generate_bokommune_16aar_snr,
+            # NudbData() - Private
+            "_snr2alder16": _generate_snr2alder16_view,
+            "_snrkat_fnr2snr": _generate_snrkat_fnr2snr_view,
             "_bof_unique_orgnrbed": _generate_bof_unique_orgnrbed_view,
             "_bof_unique_orgnr_foretak": _generate_bof_unique_orgnr_foretak_view,
             "_bof_dated_orgnr_connections": _generate_bof_dated_orgnr_connections_view,
             "_bof_eierforhold": _generate_bof_eierforhold_view,
+            # MicroData()
+            MICRODATA_PREFIX
+            + "utd_hoeyeste_nus2000": _generate_microdata_utd_hoeyeste_nus2000_view,
         }
 
         for dataset_name in external_datasets.EXTERNAL_DATASETS:
@@ -176,7 +185,7 @@ def reset_nudb_database() -> None:
 
 
 def show_nudb_datasets(show_private: bool = False) -> list[str]:
-    """Get datasets in _NudbDatabase.
+    """Get datasets in _nudb_database.
 
     Args:
         show_private: Should private datasets be shown?

--- a/src/nudb_use/variables/specific_vars/kommuner.py
+++ b/src/nudb_use/variables/specific_vars/kommuner.py
@@ -4,8 +4,8 @@ import klass
 import pandas as pd
 from nudb_config import settings
 
-from nudb_use import LoggerStack
-from nudb_use import logger
+from nudb_use.nudb_logger import LoggerStack
+from nudb_use.nudb_logger import logger
 
 EXTRA_KOMMNR = settings.constants.extra_municipality_nr
 

--- a/tests/datasets/test_nudbdata.py
+++ b/tests/datasets/test_nudbdata.py
@@ -8,6 +8,7 @@ from nudb_use.datasets import NudbData
 from nudb_use.datasets import nudb_database as nudb_database_module
 from nudb_use.datasets import reset_nudb_database
 from nudb_use.datasets.external import _generate_view
+from nudb_use.datasets.microdata import MicroData
 from nudb_use.datasets.nudb_data import _fetch_string_column
 from nudb_use.datasets.nudb_data import _is_in_database
 from nudb_use.datasets.nudb_data import _is_table
@@ -144,3 +145,20 @@ def test_external_generate_view_uses_alias_and_excludes_index(
     assert "__index_level_0__" not in columns
     assert "col" in columns
     assert "nudb_dataset_id" in columns
+
+
+def test_microdata(
+    igang: pd.DataFrame,
+    avslutta: pd.DataFrame,
+    eksamen: pd.DataFrame,
+    freg_situttak: pd.DataFrame,
+    snrkat: pd.DataFrame,
+    slekt: pd.DataFrame,
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    patch_nudb_database(
+        igang, avslutta, eksamen, freg_situttak, snrkat, slekt, tmp_path, monkeypatch
+    )
+
+    MicroData("utd_hoeyeste_nus2000")


### PR DESCRIPTION
Added a `MicroData()` function, mirroring `NudbData()`.
```python
from nudb_use.datasets import MicroData
MicroData("utd_hoeyeste_nus2000").where("snr=='xxxxxxx'").sql()
```
```
┌────────────────────────────────────────────────────────────────────────────┐
│           Getting NUDB dataset (_MICRODATA_UTD_HOEYESTE_NUS2000)           │
├────────────────────────────────────────────────────────────────────────────┘
│
├─── INFO      Initializing dataset!
│   
│   ┌─────────────────────────────────────────────────────────┐
│   │           Getting NUDB dataset (UTD_HOEYESTE)           │
│   ├─────────────────────────────────────────────────────────┘
│   │
│   ├─── INFO      Dataset is already initialized!
│   └─── INFO      EXITING STACK [Getting NUDB dataset (UTD_HOEYESTE)]
│                  
├─── INFO      Deriving `utd_hoeyeste_nus2000` Microdata variable.
└─── INFO      EXITING STACK [Getting NUDB dataset (_MICRODATA_UTD_HOEYESTE_NUS2000)]
               

┌─────────┬──────────────────────┬─────────────────────┬─────────────────────┐
│   snr   │ utd_hoeyeste_nus2000 │   gyldig_fra_dato   │   gyltid_til_dato   │
│ varchar │       varchar        │      timestamp      │      timestamp      │
├─────────┼──────────────────────┼─────────────────────┼─────────────────────┤
│ xxxxxxx │ 201103               │ 2016-06-01 00:00:00 │ 2019-06-01 00:00:00 │
│ xxxxxxx │ 416905               │ 2019-06-01 00:00:00 │ 2021-06-01 00:00:00 │
│ xxxxxxx │ 636199               │ 2021-06-01 00:00:00 │ 2022-06-01 00:00:00 │
│ xxxxxxx │ 636102               │ 2022-06-01 00:00:00 │ 2024-06-01 00:00:00 │
│ xxxxxxx │ 736104               │ 2024-06-01 00:00:00 │ NULL                │
└─────────┴──────────────────────┴─────────────────────┴─────────────────────┘
```