### PR TITLE
Vibe coding a faster orgnr-double-classification logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ssb-nudb-use"
-version = "2026.5.5"  # Year.Month.Patch - So the last number is not day of month, but patch number within month
+version = "2026.5.7"  # Year.Month.Patch - So the last number is not day of month, but patch number within month
 description = "NUDB Use - is a usage-package for the Norwegian National Education Database cloud-data. Both for data-consumers and data-deliverers"
 authors = [{ name = "Carl F. Corneil", email = "cfc@ssb.no" }, { name = "Kjell Slupphaug", email = "pph@ssb.no" }, { name = "Markus Storeide", email = "rku@ssb.no" }]
 maintainers = [{ name = "Statistics Norway, Education statistics Department (360)" }]

--- a/src/nudb_use/datasets/bof.py
+++ b/src/nudb_use/datasets/bof.py
@@ -14,7 +14,9 @@ from nudb_use.variables.checks import pyarrow_columns_from_metadata
 UNION_ALL = "\nUNION ALL\n"
 
 
-def _bof_latest_orgnr_placement_ctes_sql() -> str | None:
+def _bof_latest_orgnr_placement_ctes_sql(
+    relevant_orgnr_cte: str | None = None,
+) -> str | None:
     """Return CTE SQL for latest BOF placement of each orgnr."""
     paths = _get_all_bof_situttak_october_paths()
     union_parts: list[str] = []
@@ -41,6 +43,11 @@ def _bof_latest_orgnr_placement_ctes_sql() -> str | None:
     if not union_parts:
         return None
 
+    relevant_orgnr_filter = (
+        ""
+        if relevant_orgnr_cte is None
+        else f"AND orgnr IN (SELECT orgnr FROM {relevant_orgnr_cte})"
+    )
     placements_sql = UNION_ALL.join(union_parts)
     return f"""
         placements AS (
@@ -69,6 +76,7 @@ def _bof_latest_orgnr_placement_ctes_sql() -> str | None:
                     orgnr IS NOT NULL AND
                     TRIM(orgnr) != '' AND
                     orgnr != '000000000'
+                    {relevant_orgnr_filter}
             )
             WHERE placement_rank = 1
         )
@@ -292,8 +300,17 @@ def _generate_bof_dated_orgnr_connections_view(
     connection: db.DuckDBPyConnection,
 ) -> None:
     """All the unique orgnr <-> orgnrbed connections from october-files and the first and last files with orgnrbed in."""
+    logger.info("Finding BOF files for dated orgnr connections.")
     paths = _get_all_bof_situttak_october_paths(want_cols=("org_nr", "orgnrbed"))
+    logger.info(f"Found {len(paths)} BOF files for dated orgnr connections.")
+
+    logger.info("Building latest orgnr placement CTE for dated orgnr connections.")
     latest_placement_ctes_sql = _bof_latest_orgnr_placement_ctes_sql()
+    logger.info(
+        "Latest orgnr placement CTE for dated orgnr connections is "
+        f"{'available' if latest_placement_ctes_sql is not None else 'empty'}."
+    )
+
     union_parts: list[str] = []
     for path in paths:
         path_str = str(path).replace("'", "''")
@@ -322,6 +339,9 @@ def _generate_bof_dated_orgnr_connections_view(
         )
         return
 
+    logger.info(
+        f"Building dated orgnr connections view SQL from {len(union_parts)} BOF file parts."
+    )
     union_sql = UNION_ALL.join(union_parts)
 
     query = f"""
@@ -351,7 +371,90 @@ def _generate_bof_dated_orgnr_connections_view(
         ;
     """
 
+    logger.info(f"Creating DuckDB view {alias} for dated orgnr connections.")
     connection.sql(query)
+    logger.info(f"Created DuckDB view {alias} for dated orgnr connections.")
+
+
+def _bof_dated_orgnr_connections_lookup_sql(
+    input_alias: str,
+    orgnr_col: str,
+    orgnrbed_col: str,
+) -> str | None:
+    """Return SQL for BOF connections limited to orgnr values in an input table."""
+    paths = _get_all_bof_situttak_october_paths(want_cols=("org_nr", "orgnrbed"))
+    latest_placement_ctes_sql = _bof_latest_orgnr_placement_ctes_sql(
+        relevant_orgnr_cte="relevant_orgnr"
+    )
+    union_parts: list[str] = []
+    for path in paths:
+        path_str = str(path).replace("'", "''")
+        path_period = _first_date_from_path_period(path).strftime(r"%Y-%m-%d")
+
+        union_parts.append(f"""
+            SELECT DISTINCT
+                CAST(org_nr AS VARCHAR) AS orgnr,
+                CAST(orgnrbed AS VARCHAR) AS orgnrbed,
+                CAST('{path_period}' AS DATE) AS bof_period_date
+            FROM read_parquet('{path_str}')
+            """)
+
+    if not union_parts or latest_placement_ctes_sql is None:
+        return None
+
+    union_sql = UNION_ALL.join(union_parts)
+    return f"""
+        WITH input_foretak AS (
+            SELECT DISTINCT
+                CAST({orgnr_col} AS VARCHAR) AS orgnr
+            FROM {input_alias}
+            WHERE
+                {orgnr_col} IS NOT NULL AND
+                TRIM(CAST({orgnr_col} AS VARCHAR)) != '' AND
+                CAST({orgnr_col} AS VARCHAR) != '000000000'
+        ),
+
+        input_orgnrbed AS (
+            SELECT DISTINCT
+                CAST({orgnrbed_col} AS VARCHAR) AS orgnr
+            FROM {input_alias}
+            WHERE
+                {orgnrbed_col} IS NOT NULL AND
+                TRIM(CAST({orgnrbed_col} AS VARCHAR)) != '' AND
+                CAST({orgnrbed_col} AS VARCHAR) != '000000000'
+        ),
+
+        relevant_orgnr AS (
+            SELECT orgnr FROM input_foretak
+            UNION
+            SELECT orgnr FROM input_orgnrbed
+        ),
+
+        raw_connections AS (
+            SELECT *
+            FROM ({union_sql})
+            WHERE
+                orgnrbed IS NOT NULL AND
+                orgnr IS NOT NULL AND TRIM(orgnr) != '' AND orgnr != '000000000' AND
+                TRIM(orgnrbed) != '' AND orgnrbed != '000000000' AND
+                orgnr IN (SELECT orgnr FROM input_foretak) AND
+                orgnrbed IN (SELECT orgnr FROM input_orgnrbed)
+        ),
+
+        {latest_placement_ctes_sql}
+
+        SELECT DISTINCT
+            conn.orgnr,
+            conn.orgnrbed
+        FROM raw_connections AS conn
+        JOIN latest_placement AS orgnr_class
+            ON conn.orgnr = orgnr_class.orgnr
+           AND orgnr_class.orgnr_type = 'foretak'
+        JOIN latest_placement AS orgnrbed_class
+            ON conn.orgnrbed = orgnrbed_class.orgnr
+           AND orgnrbed_class.orgnr_type = 'orgnrbed'
+        ;
+    """
 
 
 @lru_cache

--- a/src/nudb_use/metadata/nudb_config/find_var_missing.py
+++ b/src/nudb_use/metadata/nudb_config/find_var_missing.py
@@ -208,7 +208,10 @@ def find_var_renames(var_names: list[str]) -> dict[str, list[str]]:
     return {
         v["name"]: v["renamed_from"]
         for v in lookup.values()
-        if v is not None and "renamed_from" in v and len(v["renamed_from"])
+        if v is not None and 
+            "renamed_from" in v and 
+            v["renamed_from"] is not None and 
+            len(v["renamed_from"])
     }
 
 

--- a/src/nudb_use/metadata/nudb_config/find_var_missing.py
+++ b/src/nudb_use/metadata/nudb_config/find_var_missing.py
@@ -208,10 +208,10 @@ def find_var_renames(var_names: list[str]) -> dict[str, list[str]]:
     return {
         v["name"]: v["renamed_from"]
         for v in lookup.values()
-        if v is not None and 
-            "renamed_from" in v and 
-            v["renamed_from"] is not None and 
-            len(v["renamed_from"])
+        if v is not None
+        and "renamed_from" in v
+        and v["renamed_from"] is not None
+        and len(v["renamed_from"])
     }
 
 

--- a/src/nudb_use/quality/specific_variables/nus2000.py
+++ b/src/nudb_use/quality/specific_variables/nus2000.py
@@ -79,7 +79,7 @@ def subcheck_nus2000_valid_nus(col: pd.Series | None) -> NudbQualityError | None
     nus_maske_ok = (col.str[0].isin([str(x) for x in range(1, 9)])) & (
         col.str.len() == 6
     )
-    non_valid_nus = ", ".join(list(col[~nus_maske_ok].unique()))
+    non_valid_nus = ", ".join(str(nus) for nus in col[~nus_maske_ok].unique())
 
     if len(non_valid_nus):
         err = NudbQualityError(f"Nonvalid nuscodes: {non_valid_nus}")

--- a/src/nudb_use/quality/specific_variables/orgnr.py
+++ b/src/nudb_use/quality/specific_variables/orgnr.py
@@ -1,6 +1,9 @@
+from time import perf_counter
+
 import pandas as pd
 
-from nudb_use.datasets.nudb_data import NudbData
+from nudb_use.datasets.bof import _bof_dated_orgnr_connections_lookup_sql
+from nudb_use.datasets.nudb_database import nudb_database
 from nudb_use.exceptions.exception_classes import NudbQualityError
 from nudb_use.nudb_logger import LoggerStack
 from nudb_use.nudb_logger import logger
@@ -212,29 +215,62 @@ def subcheck_orgnrbed_orgnr_foretak_connected(
     check_connections.columns = [col_foretak_name, col_orgnrbed_name]
     check_connections = check_connections[check_connections.notna().all(axis=1)]
     check_connections = check_connections.astype("string").drop_duplicates()
+    logger.info(
+        "Prepared "
+        f"{len(check_connections)} distinct non-empty {col_foretak_name}/{col_orgnrbed_name} "
+        "pairs to validate against BOF."
+    )
 
     if check_connections.empty:
+        logger.info(
+            f"No complete {col_foretak_name}/{col_orgnrbed_name} pairs to validate."
+        )
         return None
 
-    orgnr_foretak_str = "', '".join(
-        str(value).replace("'", "''")
-        for value in check_connections[col_foretak_name].unique()
-    )
-    orgnrbed_str = "', '".join(
-        str(value).replace("'", "''")
-        for value in check_connections[col_orgnrbed_name].unique()
-    )
-    bof_connections = (
-        NudbData("_bof_dated_orgnr_connections")
-        .select("DISTINCT orgnr, orgnrbed")
-        .where(
-            f"""orgnr in ('{orgnr_foretak_str}') OR orgnrbed in ('{orgnrbed_str}')"""
-        )
-        .df()
-        .astype("string")
-        .rename(columns={"orgnr": col_foretak_name})
+    n_unique_orgnr_foretak = check_connections[col_foretak_name].nunique(dropna=True)
+    n_unique_orgnrbed = check_connections[col_orgnrbed_name].nunique(dropna=True)
+    logger.info(
+        "Preparing BOF connection lookup for "
+        f"{n_unique_orgnr_foretak} unique {col_foretak_name} values and "
+        f"{n_unique_orgnrbed} unique {col_orgnrbed_name} values."
     )
 
+    logger.info("Registering input orgnr connection pairs in DuckDB.")
+    con = nudb_database.get_connection()
+    con.register("orgnr_connection_check_input", check_connections)
+    lookup_sql = _bof_dated_orgnr_connections_lookup_sql(
+        input_alias="orgnr_connection_check_input",
+        orgnr_col=col_foretak_name,
+        orgnrbed_col=col_orgnrbed_name,
+    )
+
+    if lookup_sql is None:
+        logger.warning(
+            "Found no BOF files to build targeted orgnr connection lookup. Treating BOF lookup as empty."
+        )
+        bof_connections = pd.DataFrame(columns=["orgnr", "orgnrbed"])
+    else:
+        logger.info(
+            "Executing targeted BOF connection lookup query. If processing stops here, "
+            "DuckDB is scanning BOF files for only the orgnr values present in this dataset."
+        )
+        start = perf_counter()
+        bof_connections = con.sql(lookup_sql).df()
+        logger.info(
+            "Finished targeted BOF connection lookup query in "
+            f"{perf_counter() - start:.1f}s. Got {len(bof_connections)} distinct BOF pairs."
+        )
+
+    logger.info(
+        "Finished BOF connection lookup preparation for "
+        f"{n_unique_orgnr_foretak} unique {col_foretak_name} values and "
+        f"{n_unique_orgnrbed} unique {col_orgnrbed_name} values."
+    )
+    bof_connections = bof_connections.astype("string").rename(
+        columns={"orgnr": col_foretak_name}
+    )
+
+    logger.info("Merging input pairs with BOF connection lookup result.")
     missing_connections_df = check_connections.merge(
         bof_connections,
         on=[col_foretak_name, col_orgnrbed_name],
@@ -244,6 +280,9 @@ def subcheck_orgnrbed_orgnr_foretak_connected(
     missing_connections_df = missing_connections_df[
         missing_connections_df["_merge"] == "left_only"
     ][[col_foretak_name, col_orgnrbed_name]]
+    logger.info(
+        f"Found {len(missing_connections_df)} missing BOF connection pairs after merge."
+    )
 
     if missing_connections_df.empty:
         return None

--- a/tests/quality/specific_variables/test_orgnr.py
+++ b/tests/quality/specific_variables/test_orgnr.py
@@ -141,8 +141,7 @@ def test_subcheck_orgnrbed_orgnr_foretak_connected_reports_missing_bof_pairs(
         lambda **_kwargs: "SELECT fake_bof_connections",
     )
     monkeypatch.setattr(
-        orgnr_quality.nudb_database,
-        "get_connection",
+        "nudb_use.quality.specific_variables.orgnr.nudb_database.get_connection",
         lambda: FakeConnection(),
     )
 
@@ -200,8 +199,7 @@ def test_check_orgnrbed_reports_invalid_connections_with_stubbed_bof(
         lambda **_kwargs: "SELECT fake_bof_connections",
     )
     monkeypatch.setattr(
-        orgnr_quality.nudb_database,
-        "get_connection",
+        "nudb_use.quality.specific_variables.orgnr.nudb_database.get_connection",
         lambda: FakeConnection(),
     )
 

--- a/tests/quality/specific_variables/test_orgnr.py
+++ b/tests/quality/specific_variables/test_orgnr.py
@@ -122,23 +122,29 @@ def test_subcheck_orgnrbed_orgnr_foretak_connected_reports_missing_bof_pairs(
         dtype="string",
     )
 
-    class FakeNudbData:
-        def __init__(self, name: str) -> None:
-            assert name == "_bof_dated_orgnr_connections"
-
-        def select(self, expr: str) -> "FakeNudbData":
-            assert expr == "DISTINCT orgnr, orgnrbed"
-            return self
-
-        def where(self, expr: str) -> "FakeNudbData":
-            assert "orgnr in" in expr
-            assert "orgnrbed in" in expr
-            return self
-
+    class FakeResult:
         def df(self) -> pd.DataFrame:
             return bof_connections.copy()
 
-    monkeypatch.setattr(orgnr_quality, "NudbData", FakeNudbData)
+    class FakeConnection:
+        def register(self, alias: str, df: pd.DataFrame) -> None:
+            assert alias == "orgnr_connection_check_input"
+            assert len(df) == 3
+
+        def sql(self, sql: str) -> FakeResult:
+            assert sql == "SELECT fake_bof_connections"
+            return FakeResult()
+
+    monkeypatch.setattr(
+        orgnr_quality,
+        "_bof_dated_orgnr_connections_lookup_sql",
+        lambda **_kwargs: "SELECT fake_bof_connections",
+    )
+    monkeypatch.setattr(
+        orgnr_quality.nudb_database,
+        "get_connection",
+        lambda: FakeConnection(),
+    )
 
     err = subcheck_orgnrbed_orgnr_foretak_connected(
         col_foretak=pd.Series(
@@ -175,20 +181,29 @@ def test_check_orgnrbed_reports_invalid_connections_with_stubbed_bof(
         dtype="string",
     )
 
-    class FakeNudbData:
-        def __init__(self, name: str) -> None:
-            assert name == "_bof_dated_orgnr_connections"
-
-        def select(self, expr: str) -> "FakeNudbData":
-            return self
-
-        def where(self, expr: str) -> "FakeNudbData":
-            return self
-
+    class FakeResult:
         def df(self) -> pd.DataFrame:
             return bof_connections.copy()
 
-    monkeypatch.setattr(orgnr_quality, "NudbData", FakeNudbData)
+    class FakeConnection:
+        def register(self, alias: str, df: pd.DataFrame) -> None:
+            assert alias == "orgnr_connection_check_input"
+            assert len(df) == 3
+
+        def sql(self, sql: str) -> FakeResult:
+            assert sql == "SELECT fake_bof_connections"
+            return FakeResult()
+
+    monkeypatch.setattr(
+        orgnr_quality,
+        "_bof_dated_orgnr_connections_lookup_sql",
+        lambda **_kwargs: "SELECT fake_bof_connections",
+    )
+    monkeypatch.setattr(
+        orgnr_quality.nudb_database,
+        "get_connection",
+        lambda: FakeConnection(),
+    )
 
     df = pd.DataFrame(
         {


### PR DESCRIPTION
- Trying to make orgnr-check run faster with a smaller view of "the orgnr values which have been in both orgnrbed and orgnr columns historically"
- Fix bug in new function `find_var_renames` which failed on renamed_from being None in config
- Fix bug in nus2000-quality control where NA in column made .join() fail on non-string values.