### PR TITLE
Improved docstrings in derive functions

### DIFF
--- a/src/nudb_use/variables/derive/derive_decorator.py
+++ b/src/nudb_use/variables/derive/derive_decorator.py
@@ -28,6 +28,13 @@ class DeriveError(Exception):
     ...
 
 
+def _indent_string(string: str, indent: str, first_line: bool = True) -> str:
+    if first_line:
+        string = indent + string
+
+    return string.replace("\n", "\n" + indent)
+
+
 def get_derive_function(varname: str) -> Callable[..., pd.DataFrame] | None:
     """Return the derive function for a variable if it exists.
 
@@ -214,14 +221,18 @@ def wrap_derive(
 
     wrapper.__name__ = basefunc.__name__
     docstring = basefunc.__doc__ or ""
-    wrapper.__doc__ = f"""{docstring}
-
+    wrapper.__doc__ = f"""
             Args:
                 df: Dataframe that should contain prerequisites listed in {derived_from}.
                 priority: 'old' keeps existing {name} values when present, 'new' prefers freshly derived values.
 
             Returns:
                 pd.DataFrame: The dataframe with {name} added/updated when all prerequisites are available.
+
+            Base Function Documentation:
+{_indent_string(docstring, indent = '                ')}
+            Base Function Source Code:
+{_indent_string(inspect.getsource(basefunc), indent = '                ')}
         """
     return wrapper
 
@@ -271,8 +282,7 @@ def wrap_derive_join_all_data(
 
     subfunc.__name__ = basefunc.__name__
     docstring = basefunc.__doc__ or ""
-    subfunc.__doc__ = f"""{docstring}
-
+    subfunc.__doc__ = f"""
             Args:
                 df: Dataframe that we should merge the variable data onto.
                 priority: 'old' keeps existing {name} values when present, 'new' prefers freshly derived values.
@@ -280,6 +290,11 @@ def wrap_derive_join_all_data(
 
             Returns:
                 pd.DataFrame: The dataframe with {name} added/updated.
+
+            Base Function Documentation:
+{_indent_string(docstring, indent = '                ')}
+            Base Function Source Code:
+{_indent_string(inspect.getsource(subfunc), indent = '                ')}
         """
 
     return subfunc


### PR DESCRIPTION
The formatting and information in docstrings for functions created with the decorators in `src/nudb_use/variables/derive/derive_decorator.py` is quite hit or miss. I made some slight changes improving the formatting, and adding additional relevant information.

# Examples
## `derive.uh_foerste_registrerty_dato`
This is the old docstring for `derive.uh_foerste_registrert_dato`:
```
Help on function uh_foerste_registrert_dato in module nudb_use.variables.derive.derive_decorator:

uh_foerste_registrert_dato(
    df: pandas.DataFrame | None = None,
    priority: Literal['old', 'new'] = 'old',
    temp_col_renames: dict[str, str] | None = None,
    *args: P.args,
    **kwargs: P.kwargs
) -> pandas.DataFrame
    Derive uh_foerste_registrert_dato from avslutta.

    Args:
        df: Source dataset containing at least snr, uh_erhoeyereutd_registrering, utd_aktivitet_start.

    Returns:
        pd.DataFrame: A column suitable for adding as a new column to the df.


                Args:
                    df: Dataframe that we should merge the variable data onto.
                    priority: 'old' keeps existing uh_foerste_registrert_dato values when present, 'new' prefers freshly derived values.
                    temp_col_renames: Temporary source-to-prerequisite rename mapping passed through to `wrap_derive`.

                Returns:
                    pd.DataFrame: The dataframe with uh_foerste_registrert_dato added/updated.

```
This is the new docstring:
```
Help on function uh_foerste_registrert_dato in module nudb_use.variables.derive.derive_decorator:

uh_foerste_registrert_dato(
    df: pandas.DataFrame | None = None,
    priority: Literal['old', 'new'] = 'old',
    temp_col_renames: dict[str, str] | None = None,
    *args: P.args,
    **kwargs: P.kwargs
) -> pandas.DataFrame
    Args:
        df: Dataframe that we should merge the variable data onto.
        priority: 'old' keeps existing uh_foerste_registrert_dato values when present, 'new' prefers freshly derived values.
        temp_col_renames: Temporary source-to-prerequisite rename mapping passed through to `wrap_derive`.

    Returns:
        pd.DataFrame: The dataframe with uh_foerste_registrert_dato added/updated.

    Base Function Documentation:
        Derive uh_foerste_registrert_dato from avslutta.

        Args:
            df: Source dataset containing at least snr, uh_erhoeyereutd_registrering, utd_aktivitet_start.

        Returns:
            pd.DataFrame: A column suitable for adding as a new column to the df.


    Base Function Location:
        nudb_use/variables/derive/derive_decorator.py

    Base Function Source Code:
            def subfunc(
                df: pd.DataFrame | None = None,
                priority: Literal["old", "new"] = "old",
                temp_col_renames: dict[str, str] | None = None,
                *args: P.args,
                **kwargs: P.kwargs,
            ) -> pd.DataFrame:
                with LoggerStack(f"Deriving variable {name}, using whole NUDB-datasets."):
                    source_data = get_source_data(name, df)

                    basefunc_wrapped = wrap_derive(basefunc)
                    derived_source = basefunc_wrapped(
                        source_data,
                        *args,
                        priority=priority,
                        temp_col_renames=temp_col_renames,
                        **kwargs,
                    )

                    if df is None:
                        logger.warning("data is None, why u do this?")
                        return derived_source

                    try:
                        return join_variable_data(name, derived_source, df)
                    except Exception:
                        logger.warning(f"Unable to join {name} onto data! Returning as is...")
                        return df

```
## `derive.utd_hoeyeste_nus2000`
This is the old docstring for `derive.utd_hoeyeste_nus2000:
```
Help on function utd_hoeyeste_nus2000 in module nudb_use.variables.derive.derive_decorator:

utd_hoeyeste_nus2000(
    df: pandas.DataFrame,
    priority: Literal['old', 'new'] = 'old',
    temp_col_renames: dict[str, str] | None = None,
    raise_errors: bool = False,
    *args: P.args,
    **kwargs: P.kwargs
) -> pandas.DataFrame
    Derive `utd_hoyeste_nus2000`.

    Args:
        df: Dataframe that should contain prerequisites listed in ['snr'].
        priority: 'old' keeps existing utd_hoeyeste_nus2000 values when present, 'new' prefers freshly derived values.

    Returns:
        pd.DataFrame: The dataframe with utd_hoeyeste_nus2000 added/updated when all prerequisites are available.

```
This is the new docstring:
```
Help on function utd_hoeyeste_nus2000 in module nudb_use.variables.derive.derive_decorator:

utd_hoeyeste_nus2000(
    df: pandas.DataFrame,
    priority: Literal['old', 'new'] = 'old',
    temp_col_renames: dict[str, str] | None = None,
    raise_errors: bool = False,
    *args: P.args,
    **kwargs: P.kwargs
) -> pandas.DataFrame
    Args:
        df: Dataframe that should contain prerequisites listed in ['snr'].
        priority: 'old' keeps existing utd_hoeyeste_nus2000 values when present, 'new' prefers freshly derived values.

    Returns:
        pd.DataFrame: The dataframe with utd_hoeyeste_nus2000 added/updated when all prerequisites are available.

    Base Function Documentation:
        Derive `utd_hoyeste_nus2000`.

    Base Function Location:
        nudb_use/variables/derive/utd_hoeyeste.py

    Base Function Source Code:
        @wrap_derive
        def utd_hoeyeste_nus2000(df: pd.DataFrame, year_col: str | None = None) -> pd.Series:
            """Derive `utd_hoyeste_nus2000`."""
            df = df.copy()

            varname = "utd_hoeyeste_nus2000"
            if varname in df.columns:
                logger.warning(
                    f'{varname} already exists... If `priority="old"` some values might not get updated!'
                )
                df = df.drop(columns=varname)

            year_col_right = "utd_hoeyeste_aar"
            if not year_col:
                year_col = year_col_right
                df[year_col] = dt.datetime.now().year

            df["snr"] = df["snr"].astype(STRING_DTYPE)
            df[year_col_right] = df[year_col].astype(INTEGER_DTYPE)

            utd_hoeyeste = NudbData("utd_hoeyeste")

            con = nudb_database.get_connection()
            con.register("_tmp_df", df[["snr", year_col_right]].drop_duplicates())

            mapping = con.sql(f"""
                SELECT DISTINCT
                    T1.snr,
                    T1.{year_col_right},
                    T2.utd_hoeyeste_nus2000 AS {varname}
                FROM
                    _tmp_df AS T1
                ASOF LEFT JOIN
                    {utd_hoeyeste.alias} AS T2
                ON
                    T1.snr = T2.snr AND
                    T2.{year_col_right} <= T1.{year_col_right};
            """).df()

            result = df.merge(
                right=mapping, on=["snr", year_col_right], how="left", validate="m:1"
            )

            if result.shape[0] > df.shape[0]:
                logger.warning(
                    f"Number of observations grew from {df.shape[0]} to {result.shape[0]}!"
                )
            elif result.shape[0] < df.shape[0]:
                logger.warning(
                    f"Number of observations decreased from {df.shape[0]} to {result.shape[0]}!"
                )

            return result[varname]

```